### PR TITLE
Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ The core component of cyphernode is a request handler which exposes HTTP endpoin
 
 ## Documentation
 
-* Read the API docs here: https://github.com/SatoshiPortal/cyphernode/blob/master/doc/API.md
+* Read the API docs here: 
+  * API v0 (Current): https://github.com/SatoshiPortal/cyphernode/blob/master/doc/API.v0.md
+  * API v1 (RESTful): https://github.com/SatoshiPortal/cyphernode/blob/master/doc/API.v1.md 
 * Installation documentation: https://github.com/SatoshiPortal/cyphernode/blob/master/doc/INSTALL.md
 * Step-by-step manual install (deprecated): https://github.com/SatoshiPortal/cyphernode/blob/master/doc/INSTALL-MANUAL-STEPS.md
 


### PR DESCRIPTION
This PR replaces the 404 API docs links with v0 and v1 API docs links in README.md

The following links are still broken:

1. www.satoshiportal.com
2. https://github.com/SatoshiPortal/cyphernode/blob/master/doc/SATOSHIPORTAL-WORKFLOW.md (not broken, but empty file)

Are there updated links to the above? Or should they be removed completely? 