### PR TITLE
change fee type to integer

### DIFF
--- a/doc/openapi/v0/cyphernode-api.yaml
+++ b/doc/openapi/v0/cyphernode-api.yaml
@@ -1957,7 +1957,7 @@ components:
         vout:
           type: "integer"
         fee:
-          type: "fee"
+          type: "integer"
         confirmations:
           type: "integer"
         blockhash:


### PR DESCRIPTION
Noticed when importing into editor.swagger.io

<img width="712" alt="Screen Shot 2020-02-06 at 5 17 37 PM" src="https://user-images.githubusercontent.com/12980165/73983891-75e7a180-4905-11ea-8a5d-7a5c82cb3f36.png">

This should simply be an integer if it's referring to the `sat/byte` type of fee.