### PR TITLE
added bitcoin core rpc gettxoutsetinfo

### DIFF
--- a/api_auth_docker/api-sample.properties
+++ b/api_auth_docker/api-sample.properties
@@ -6,6 +6,7 @@ action_getblockchaininfo=stats
 action_installation_info=stats
 action_getmempoolinfo=stats
 action_getblockhash=stats
+action_gettxoutsetinfo=stats
 
 # Watcher can do what the stats can do, plus:
 action_watch=watcher

--- a/cyphernodeconf_docker/templates/gatekeeper/api.properties
+++ b/cyphernodeconf_docker/templates/gatekeeper/api.properties
@@ -9,6 +9,7 @@ action_getblockchaininfo=stats
 action_installation_info=stats
 action_getmempoolinfo=stats
 action_getblockhash=stats
+action_gettxoutsetinfo=stats
 
 # Watcher can:
 action_watch=watcher

--- a/doc/API.v0.md
+++ b/doc/API.v0.md
@@ -313,6 +313,29 @@ Proxy response:
   "minrelaytxfee": 1e-05
 }
 ```
+## Get the unspent transaction output set statistics
+
+Returns statistics about the unspent transaction output set.
+Note this call may take some time.
+
+```http
+GET http://cyphernode:8888/gettxoutsetinfo
+```
+
+Proxy response:
+
+```json
+{
+  "height": 1486864,
+  "bestblock": "000000000000002fb99d683e64bbfc2b7ad16f9a425cf7be77b481fb1afa363b",
+  "transactions": 9197804,
+  "txouts": 24041190,
+  "bogosize": 1803311256,
+  "hash_serialized_2": "ffc1fb007587596f9183154a613843e5b55b1d285b16d7e3b0cb7cbe6b2cba06",
+  "disk_size" : 23647567017, 
+  "total_amount": 20941947.16577759,
+}
+```
 
 ### Get the blockchain information (called by application)
 
@@ -325,6 +348,7 @@ GET http://cyphernode:8888/getblockchaininfo
 Proxy response:
 
 ```json
+
 {
   "chain": "test",
   "blocks": 1486864,

--- a/proxy_docker/app/script/blockchainrpc.sh
+++ b/proxy_docker/app/script/blockchainrpc.sh
@@ -103,3 +103,11 @@ validateaddress() {
   send_to_watcher_node "${data}"
   return $?
 }
+
+gettxoutsetinfo() {
+  trace "Entering gettxoutsetinfo()..."
+
+  local data='{"method":"gettxoutsetinfo"}'
+  send_to_watcher_node "${data}" | jq ".result"
+  return $?
+}

--- a/proxy_docker/app/script/requesthandler.sh
+++ b/proxy_docker/app/script/requesthandler.sh
@@ -217,6 +217,13 @@ main() {
           response=$(get_blockchain_info)
           response_to_client "${response}" ${?}
           ;;
+        gettxoutsetinfo)
+          # http://192.168.111.152:8080/gettxoutsetinfo
+
+          response=$(gettxoutsetinfo)
+          response_to_client "${response}" ${?}
+          break
+          ;;
         gettransaction)
           # curl (GET) http://192.168.111.152:8080/gettransaction/af867c86000da76df7ddb1054b273ca9e034e8c89d049b5b2795f9f590f67648
 


### PR DESCRIPTION
added bitcoin core rpc call gettxoutsetinfo which gives information on the utxo set, such as the amount of UTXOs, the amount of transaction with UTXOs but mainly to obtain the current bitcoin supply.