### PR TITLE
Tor bumped to 0.4.7.8 + Alpine 3.15.4

### DIFF
--- a/tor_docker/Dockerfile
+++ b/tor_docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.12.4 AS builder
+FROM alpine:3.15.4 AS builder
 
-ARG TOR_VER=0.4.6.10
+ARG TOR_VER=0.4.7.8
 ARG TOR_DIR=tor-$TOR_VER
 ARG TOR_FILE=$TOR_DIR.tar.gz
 ARG TOR_DIST=https://dist.torproject.org/$TOR_FILE
@@ -10,14 +10,14 @@ RUN apk --no-cache add --update \
 
 RUN wget $TOR_DIST.sha256sum && wget $TOR_DIST.sha256sum.asc && wget $TOR_DIST
 
-RUN sed -r 's/(.) tor/\1  tor/' tor-0.4.6.10.tar.gz.sha256sum | sha256sum -c -
+RUN sed -r 's/(.) tor/\1 tor/' tor-0.4.7.8.tar.gz.sha256sum | sha256sum -c -
 
 RUN gpg --auto-key-locate nodefault,wkd --locate-keys ahf@torproject.org  dgoulet@torproject.org nickm@torproject.org \
  && gpg --verify tor-$TOR_VER.tar.gz.sha256sum.asc \
  && tar xfz $TOR_FILE && cd $TOR_DIR \
  && ./configure && make install
 
-FROM alpine:3.12.4
+FROM alpine:3.15.4
 
 RUN apk --no-cache add --update \
   su-exec


### PR DESCRIPTION
tor log:
```
Jul 09 17:34:36.233 [notice] Tor 0.4.7.8 running on Linux with Libevent 2.1.12-stable, OpenSSL 1.1.1q, Zlib 1.2.12, Liblzma N/A, Libzstd N/A and Unknown N/A as libc.
Jul 09 17:34:36.233 [notice] Tor can't help you if you use it wrong! Learn how to be safe at https://support.torproject.org/faq/staying-anonymous/
Jul 09 17:34:36.238 [notice] Read configuration file "/tor/torrc".
Jul 09 17:34:36.248 [warn] You specified a public address '0.0.0.0:9050' for SocksPort. Other people on the Internet might find your computer and use it as an open proxy. Please don't allow this unless you have a good reason.
Jul 09 17:34:36.248 [notice] Opening Socks listener on 0.0.0.0:9050
Jul 09 17:34:36.248 [notice] Opened Socks listener connection (ready) on 0.0.0.0:9050
Jul 09 17:34:36.000 [notice] Bootstrapped 0% (starting): Starting
Jul 09 17:34:36.000 [notice] Starting with guard context "default"
Jul 09 17:34:37.000 [notice] Bootstrapped 5% (conn): Connecting to a relay
Jul 09 17:34:38.000 [notice] Bootstrapped 10% (conn_done): Connected to a relay
Jul 09 17:34:38.000 [notice] Bootstrapped 14% (handshake): Handshaking with a relay
Jul 09 17:34:38.000 [notice] Bootstrapped 15% (handshake_done): Handshake with a relay done
Jul 09 17:34:38.000 [notice] Bootstrapped 75% (enough_dirinfo): Loaded enough directory info to build circuits
Jul 09 17:34:38.000 [notice] Bootstrapped 90% (ap_handshake_done): Handshake finished with a relay to build circuits
Jul 09 17:34:38.000 [notice] Bootstrapped 95% (circuit_create): Establishing a Tor circuit
Jul 09 17:34:38.000 [notice] Bootstrapped 100% (done): Done
```
