### PR TITLE
Fixed wrong ownership for cyphernode_container_monitor volume

### DIFF
--- a/cyphernodeconf_docker/templates/installer/docker/docker-compose.yaml
+++ b/cyphernodeconf_docker/templates/installer/docker/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - "<%= logs_datapath %>:/cnlogs"
       - container_monitor:/container_monitor
     healthcheck:
-      test: sh -c 'psql -U cyphernode -c "select 1;" && touch /container_monitor/postgres_ready && chown $USER /container_monitor/postgres_ready || rm -f /container_monitor/postgres_ready'
+      test: sh -c 'psql -U cyphernode -c "select 1;" && touch /container_monitor/postgres_ready || rm -f /container_monitor/postgres_ready'
       interval: 30s
       timeout: 10s
       retries: 10
@@ -52,7 +52,7 @@ services:
       - "<%= tor_datapath %>:/tor"
       - container_monitor:/container_monitor
     healthcheck:
-      test: chown -R $USER /container_monitor && su-exec $USER sh -c 'tor-resolve torproject.org && touch /container_monitor/tor_ready || rm -f /container_monitor/tor_ready'
+      test: su-exec $USER sh -c 'tor-resolve torproject.org && touch /container_monitor/tor_ready || rm -f /container_monitor/tor_ready'
       interval: 30s
       timeout: 10s
       retries: 10
@@ -93,7 +93,7 @@ services:
       - "<%= bitcoin_datapath %>/bitcoin-client.conf:/.bitcoin/bitcoin.conf:ro"
       - container_monitor:/container_monitor
     healthcheck:
-      test: lightning-cli getinfo && touch /container_monitor/lightning_ready && chown -R $USER /container_monitor || rm -f /container_monitor/lightning_ready
+      test: lightning-cli getinfo && touch /container_monitor/lightning_ready || rm -f /container_monitor/lightning_ready
       interval: 30s
       timeout: 10s
       retries: 10
@@ -140,9 +140,9 @@ services:
       - container_monitor:/container_monitor
     healthcheck:
       <% if( net === 'regtest' ) { %>
-      test: sh -c '[ `bitcoin-cli getblockcount` -ge 101 ] && touch /container_monitor/bitcoin_ready && chown -R $USER /container_monitor || rm -f /container_monitor/bitcoin_ready'
+      test: sh -c '[ `bitcoin-cli getblockcount` -ge 101 ] && touch /container_monitor/bitcoin_ready || rm -f /container_monitor/bitcoin_ready'
       <% } else { %>
-      test: bitcoin-cli echo && touch /container_monitor/bitcoin_ready && chown -R $USER /container_monitor || rm -f /container_monitor/bitcoin_ready
+      test: bitcoin-cli echo && touch /container_monitor/bitcoin_ready || rm -f /container_monitor/bitcoin_ready
       <% } %>
       interval: 30s
       timeout: 10s
@@ -198,7 +198,7 @@ services:
       <% } %>
       - container_monitor:/container_monitor
     healthcheck:
-      test: curl localhost:8888/helloworld && touch /container_monitor/proxy_ready && chown -R $USER /container_monitor || rm -f /container_monitor/proxy_ready
+      test: curl localhost:8888/helloworld && touch /container_monitor/proxy_ready || rm -f /container_monitor/proxy_ready
       interval: 30s
       timeout: 10s
       retries: 10

--- a/cyphernodeconf_docker/templates/installer/start.sh
+++ b/cyphernodeconf_docker/templates/installer/start.sh
@@ -60,8 +60,9 @@ fi
 export USER=$(id -u <%= default_username %>):$(id -g <%= default_username %>)
 <% } %>
 
-# Let's make sure the container readyness files are deleted before starting the stack
-docker run --rm -v cyphernode_container_monitor:/container_monitor alpine sh -c 'rm -f /container_monitor/*_ready'
+# Let's make sure the container_monitor folder has the right ownership and
+# container readyness files are deleted before starting the stack
+docker run --rm -v cyphernode_container_monitor:/container_monitor alpine sh -c 'chown -R '$USER' /container_monitor && rm -f /container_monitor/*_ready'
 
 <% if (docker_mode == 'swarm') { %>
 docker stack deploy -c $current_path/docker-compose.yaml cyphernode

--- a/cyphernodeconf_docker/templates/installer/start.sh
+++ b/cyphernodeconf_docker/templates/installer/start.sh
@@ -62,7 +62,7 @@ export USER=$(id -u <%= default_username %>):$(id -g <%= default_username %>)
 
 # Let's make sure the container_monitor folder has the right ownership and
 # container readyness files are deleted before starting the stack
-docker run --rm -v cyphernode_container_monitor:/container_monitor alpine sh -c 'chown -R '$USER' /container_monitor && rm -f /container_monitor/*_ready'
+docker run --rm -v cyphernode_container_monitor:/container_monitor alpine:3.15.4 sh -c 'chown -R '$USER' /container_monitor && rm -f /container_monitor/*_ready'
 
 <% if (docker_mode == 'swarm') { %>
 docker stack deploy -c $current_path/docker-compose.yaml cyphernode


### PR DESCRIPTION
The mounted volume `cyphernode_container_monitor` ownership was not changing to `$USER` since we added `user: $USER` in docker-compose file.  The container status files were not created.