### PR TITLE
fix for flock, requesthandler

### DIFF
--- a/585852a061f4
+++ b/585852a061f4
@@ -1,6 +1,0 @@
-"docker logs" requires exactly 1 argument.
-See 'docker logs --help'.
-
-Usage:  docker logs [OPTIONS] CONTAINER
-
-Fetch the logs of a container

--- a/585852a061f4
+++ b/585852a061f4
@@ -1,0 +1,6 @@
+"docker logs" requires exactly 1 argument.
+See 'docker logs --help'.
+
+Usage:  docker logs [OPTIONS] CONTAINER
+
+Fetch the logs of a container

--- a/proxy_docker/Dockerfile
+++ b/proxy_docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt update && apt -y install \
  COPY app/tests/* ./tests/
  COPY --from=cyphernode/clightning:v0.11.2-debian /usr/local/bin/lightning-cli ./
 
- RUN chmod +x startproxy.sh requesthandler.sh lightning-cli sqlmigrate*.sh waitanyinvoice.sh bitcoin_node_walletnotify.sh tests/* \
+ RUN chmod +x startproxy.sh requesthandler.sh lightning-cli sqlmigrate*.sh waitanyinvoice.sh bitcoin_node_walletnotify.sh confirmation.sh tests/* \
   && chmod o+w . \
   && mkdir db
 

--- a/proxy_docker/app/script/bitcoin_node_walletnotify.sh
+++ b/proxy_docker/app/script/bitcoin_node_walletnotify.sh
@@ -11,7 +11,7 @@ bitcoin_node_walletnotify() {
     mosquitto_sub -h broker -t bitcoin_watching_walletnotify | while read -r message
     do
       trace "[bitcoin_node_walletnotify] Processing bitcoin_watching_walletnotify from bitcoin node"
-      sh -c "./confirmation.sh '${message}'" &
+      sh -c "./confirmation.sh '${message}'"
     done
 
     trace "[bitcoin_node_walletnotify] reconnecting in 10 secs"

--- a/proxy_docker/app/script/bitcoin_node_walletnotify.sh
+++ b/proxy_docker/app/script/bitcoin_node_walletnotify.sh
@@ -11,7 +11,7 @@ bitcoin_node_walletnotify() {
     mosquitto_sub -h broker -t bitcoin_watching_walletnotify | while read -r message
     do
       trace "[bitcoin_node_walletnotify] Processing bitcoin_watching_walletnotify from bitcoin node"
-      confirmation "${message}"
+      sh -c "./confirmation.sh '${message}'" &
     done
 
     trace "[bitcoin_node_walletnotify] reconnecting in 10 secs"

--- a/proxy_docker/app/script/call_lightningd.sh
+++ b/proxy_docker/app/script/call_lightningd.sh
@@ -531,7 +531,7 @@ ln_withdraw() {
   local satoshi=$(echo "${request}" | jq -r ".satoshi")
   local feerate=$(echo "${request}" | jq -r ".feerate")
   local all=$(echo "${request}" | jq -r ".all")
-  if [ "${all}" == true ] || [ "${all}" == "true" ] ; then
+  if [ "${all}" = true ] || [ "${all}" = "true" ] ; then
       satoshi="all"
   fi
 

--- a/proxy_docker/app/script/callbacks_job.sh
+++ b/proxy_docker/app/script/callbacks_job.sh
@@ -6,7 +6,7 @@
 
 do_callbacks() {
   (
-  flock --verbose -n 8 || return 0
+  flock --verbose -n 8 1>&2 || return 0
 
   trace "Entering do_callbacks()..."
 

--- a/proxy_docker/app/script/callbacks_job.sh
+++ b/proxy_docker/app/script/callbacks_job.sh
@@ -6,7 +6,7 @@
 
 do_callbacks() {
   (
-  flock -x 8 || return 0
+  flock --verbose -n 8 || return 0
 
   trace "Entering do_callbacks()..."
 

--- a/proxy_docker/app/script/callbacks_job.sh
+++ b/proxy_docker/app/script/callbacks_job.sh
@@ -21,7 +21,7 @@ do_callbacks() {
   local returncode
   local flock_output
   
-  flock_output=$(flock --verbose --timeout 60 8 2>&1)
+  flock_output=$(flock --verbose ${flock_flag} 8 2>&1)
   returncode=$?
   trace "[do_callbacks] flock_output=${flock_output}"
   if [ "$returncode" -eq "0" ]; then

--- a/proxy_docker/app/script/callbacks_txid.sh
+++ b/proxy_docker/app/script/callbacks_txid.sh
@@ -5,7 +5,7 @@
 
 do_callbacks_txid() {
   (
-  flock --verbose -n 8 || return 0
+  flock --verbose -n 8 1>&2 || return 0
 
   trace "Entering do_callbacks_txid()..."
 

--- a/proxy_docker/app/script/callbacks_txid.sh
+++ b/proxy_docker/app/script/callbacks_txid.sh
@@ -27,7 +27,7 @@ do_callbacks_txid() {
     local url
     local id
     local IFS="
-  "
+"
     for row in ${callbacks}
     do
       build_callback_txid "${row}"

--- a/proxy_docker/app/script/callbacks_txid.sh
+++ b/proxy_docker/app/script/callbacks_txid.sh
@@ -5,7 +5,7 @@
 
 do_callbacks_txid() {
   (
-  flock -x 8 || return 0
+  flock --verbose -n 8 || return 0
 
   trace "Entering do_callbacks_txid()..."
 

--- a/proxy_docker/app/script/callbacks_txid.sh
+++ b/proxy_docker/app/script/callbacks_txid.sh
@@ -2,12 +2,15 @@
 
 . ./trace.sh
 . ./sql.sh
+. ./blockchainrpc.sh
+. ./computefees.sh
 
 do_callbacks_txid() {
-  (
-  flock --verbose -n 8 1>&2 || return 0
-
   trace "Entering do_callbacks_txid()..."
+
+  (
+  local flock_output=$(flock --verbose --nonblock 8) || (trace "[do_callbacks_txid] Exiting - flock_output=${flock_output}" && return 0)
+  trace "[do_callbacks_txid] flock_output=${flock_output}"
 
   # Let's check the 1-conf (newly mined) watched txid that are included in the new block...
 
@@ -89,7 +92,7 @@ build_callback_txid() {
 
   if [ "${returncode}" -eq "0" ]; then
     confirmations=$(echo "${tx_raw_details}" | jq '.result.confirmations')
-    if [ "${confirmations}" == "null" ]; then
+    if [ "${confirmations}" = "null" ]; then
       confirmations=0
     fi
     trace "[build_callback_txid] confirmations=${confirmations}"

--- a/proxy_docker/app/script/confirmation.sh
+++ b/proxy_docker/app/script/confirmation.sh
@@ -99,167 +99,171 @@ confirmation() {
   local txid=$(echo "$tx_details" | jq .txid | tr -d \")
 
   (
-  local flock_output=$(flock --verbose --timeout 60 9) || (trace "[confirmation]  Exiting - flock_output=${flock_output}" && return 0)
-  trace "[confirmation] flock_output=${flock_output}"
-
   local returncode
+  local flock_output
+  
+  flock_output=$(flock --verbose --timeout 60 9 2>&1)
+  returncode=$?
+  trace "[confirmation] flock_output=${flock_output}"
+  if [ "$returncode" -eq "0" ]; then
+    ########################################################################################################
+    # First of all, let's make sure we're working on watched addresses...
+    local address
+    local addresseswhere
+    local addresses=$(echo "${tx_details}" | jq -r ".details[].address")
 
-  ########################################################################################################
-  # First of all, let's make sure we're working on watched addresses...
-  local address
-  local addresseswhere
-  local addresses=$(echo "${tx_details}" | jq -r ".details[].address")
+    trace "[confirmation] addresses=${addresses}"
 
-  trace "[confirmation] addresses=${addresses}"
+    local notfirst=false
+    local IFS="
+  "
+    for address in ${addresses}
+    do
+      trace "[confirmation] address=${address}"
 
-  local notfirst=false
-  local IFS="
-"
-  for address in ${addresses}
-  do
-    trace "[confirmation] address=${address}"
-
-    if ${notfirst}; then
-      addresseswhere="${addresseswhere},'${address}'"
-    else
-      addresseswhere="'${address}'"
-      notfirst=true
+      if ${notfirst}; then
+        addresseswhere="${addresseswhere},'${address}'"
+      else
+        addresseswhere="'${address}'"
+        notfirst=true
+      fi
+    done
+    local rows=$(sql "SELECT id, address, watching_by_pub32_id, pub32_index, event_message FROM watching WHERE address IN (${addresseswhere}) AND watching")
+    if [ ${#rows} -eq 0 ]; then
+      trace "[confirmation] No watched address in this tx!"
+      return 0
     fi
-  done
-  local rows=$(sql "SELECT id, address, watching_by_pub32_id, pub32_index, event_message FROM watching WHERE address IN (${addresseswhere}) AND watching")
-  if [ ${#rows} -eq 0 ]; then
-    trace "[confirmation] No watched address in this tx!"
-    return 0
-  fi
-  ########################################################################################################
+    ########################################################################################################
 
-  local tx=$(sql "SELECT id FROM tx WHERE txid='${txid}'")
-  local id_inserted
-  local tx_nb_conf=$(echo "${tx_details}" | jq -r '.confirmations // 0')
-  local tx_hash=$(echo "${tx_details}" | jq -r '.decoded.hash')
+    local tx=$(sql "SELECT id FROM tx WHERE txid='${txid}'")
+    local id_inserted
+    local tx_nb_conf=$(echo "${tx_details}" | jq -r '.confirmations // 0')
+    local tx_hash=$(echo "${tx_details}" | jq -r '.decoded.hash')
 
-  # Sometimes raw tx are too long to be passed as paramater, so let's write
-  # it to a temp file for it to be read by sqlite3 and then delete the file
-  echo "${tx_details}" | jq -Mc '.decoded' > rawtx-${txid}-$$.blob
+    # Sometimes raw tx are too long to be passed as paramater, so let's write
+    # it to a temp file for it to be read by sqlite3 and then delete the file
+    echo "${tx_details}" | jq -Mc '.decoded' > rawtx-${txid}-$$.blob
 
-  if [ -z ${tx} ]; then
-    # TX not found in our DB.
-    # 0-conf or missed conf (managed or while spending) or spending an unconfirmed
-    # (note: spending an unconfirmed TX must be avoided or we'll get here spending an unprocessed watching)
+    if [ -z ${tx} ]; then
+      # TX not found in our DB.
+      # 0-conf or missed conf (managed or while spending) or spending an unconfirmed
+      # (note: spending an unconfirmed TX must be avoided or we'll get here spending an unprocessed watching)
 
-    # Let's first insert the tx in our DB
+      # Let's first insert the tx in our DB
 
-    local tx_ts_firstseen=$(echo "${tx_details}" | jq '.timereceived')
-    local tx_amount=$(echo "${tx_details}" | jq '.amount')
+      local tx_ts_firstseen=$(echo "${tx_details}" | jq '.timereceived')
+      local tx_amount=$(echo "${tx_details}" | jq '.amount')
 
-    local tx_size=$(echo "${tx_details}" | jq '.decoded.size')
-    local tx_vsize=$(echo "${tx_details}" | jq '.decoded.vsize')
-    local tx_replaceable=$(echo "${tx_details}" | jq -r '."bip125-replaceable"')
-    tx_replaceable=$([ ${tx_replaceable} = "yes" ] && echo "true" || echo "false")
+      local tx_size=$(echo "${tx_details}" | jq '.decoded.size')
+      local tx_vsize=$(echo "${tx_details}" | jq '.decoded.vsize')
+      local tx_replaceable=$(echo "${tx_details}" | jq -r '."bip125-replaceable"')
+      tx_replaceable=$([ ${tx_replaceable} = "yes" ] && echo "true" || echo "false")
 
-    local fees=$(compute_fees "${txid}")
-    trace "[confirmation] fees=${fees}"
-    trace "[confirmation] tx_hash=${tx_hash}"
+      local fees=$(compute_fees "${txid}")
+      trace "[confirmation] fees=${fees}"
+      trace "[confirmation] tx_hash=${tx_hash}"
 
-    # If we missed 0-conf...
-    local tx_blockhash=null
-    local tx_blockheight=null
-    local tx_blocktime=null
-    if [ "${tx_nb_conf}" -gt "0" ]; then
-      trace "[confirmation] tx_nb_conf=${tx_nb_conf}"
-      tx_blockhash="$(echo "${tx_details}" | jq -r '.blockhash')"
-      tx_blockheight=$(echo "${tx_details}" | jq -r '.blockheight')
-      tx_blockhash="'${tx_blockhash}'"
-      tx_blocktime=$(echo "${tx_details}" | jq '.blocktime')
-    fi
+      # If we missed 0-conf...
+      local tx_blockhash=null
+      local tx_blockheight=null
+      local tx_blocktime=null
+      if [ "${tx_nb_conf}" -gt "0" ]; then
+        trace "[confirmation] tx_nb_conf=${tx_nb_conf}"
+        tx_blockhash="$(echo "${tx_details}" | jq -r '.blockhash')"
+        tx_blockheight=$(echo "${tx_details}" | jq -r '.blockheight')
+        tx_blockhash="'${tx_blockhash}'"
+        tx_blocktime=$(echo "${tx_details}" | jq '.blocktime')
+      fi
 
-    id_inserted=$(sql "INSERT INTO tx (txid, hash, confirmations, timereceived, fee, size, vsize, is_replaceable, blockhash, blockheight, blocktime)"\
+      id_inserted=$(sql "INSERT INTO tx (txid, hash, confirmations, timereceived, fee, size, vsize, is_replaceable, blockhash, blockheight, blocktime)"\
 " VALUES ('${txid}', '${tx_hash}', ${tx_nb_conf}, ${tx_ts_firstseen}, ${fees}, ${tx_size}, ${tx_vsize}, ${tx_replaceable}, ${tx_blockhash}, ${tx_blockheight}, ${tx_blocktime})"\
 " ON CONFLICT (txid) DO"\
 " UPDATE SET blockhash=${tx_blockhash}, blockheight=${tx_blockheight}, blocktime=${tx_blocktime}, confirmations=${tx_nb_conf}"\
 " RETURNING id" \
-    "SELECT id FROM tx WHERE txid='${txid}'")
-    trace_rc $?
+"SELECT id FROM tx WHERE txid='${txid}'")
+      trace_rc $?
 
+    else
+      # TX found in our DB.
+      # 1-conf or executecallbacks on an unconfirmed tx or spending watched address (in this case, we probably missed conf) or spending to a watched address (in this case, spend inserted the tx in the DB)
+
+      local tx_blockhash=$(echo "${tx_details}" | jq -r '.blockhash')
+      trace "[confirmation] tx_blockhash=${tx_blockhash}"
+      if [ "${tx_blockhash}" = "null" ]; then
+        trace "[confirmation] probably being called by executecallbacks without any confirmations since the last time we checked"
+      else
+        local tx_blockheight=$(echo "${tx_details}" | jq -r '.blockheight')
+        local tx_blocktime=$(echo "${tx_details}" | jq '.blocktime')
+
+        sql "UPDATE tx SET confirmations=${tx_nb_conf}, blockhash='${tx_blockhash}', blockheight=${tx_blockheight}, blocktime=${tx_blocktime} WHERE txid='${txid}'"
+        trace_rc $?
+      fi
+      id_inserted=${tx}
+    fi
+    # Delete the temp file containing the raw tx (see above)
+    rm rawtx-${txid}-$$.blob
+
+    ########################################################################################################
+
+    local event_message
+    local watching_id
+
+    # Let's see if we need to insert tx in the join table
+    tx=$(sql "SELECT tx_id FROM watching_tx WHERE tx_id=${id_inserted}")
+
+    for row in ${rows}
+    do
+
+      address=$(echo "${row}" | cut -d '|' -f2)
+      tx_vout_amount=$(echo "${tx_details}" | jq ".details | map(select(.address==\"${address}\"))[0] | .amount | fabs" | awk '{ printf "%.8f", $0 }')
+      # In the case of us spending to a watched address, the address appears twice in the details,
+      # once on the spend side (negative amount) and once on the receiving side (positive amount)
+      tx_vout_n=$(echo "${tx_details}" | jq ".details | map(select(.address==\"${address}\"))[0] | .vout")
+
+      ########################################################################################################
+      # Let's now insert in the join table if not already done
+      if [ -z "${tx}" ]; then
+        trace "[confirmation] For this tx, there's no watching_tx row, let's create it"
+
+        # If the tx is batched and pays multiple watched addresses, we have to insert
+        # those additional addresses in watching_tx!
+        watching_id=$(echo "${row}" | cut -d '|' -f1)
+        sql "INSERT INTO watching_tx (watching_id, tx_id, vout, amount) VALUES (${watching_id}, ${id_inserted}, ${tx_vout_n}, ${tx_vout_amount})"\
+  " ON CONFLICT DO NOTHING"
+        trace_rc $?
+      else
+        trace "[confirmation] For this tx, there's already watching_tx rows"
+      fi
+      ########################################################################################################
+
+      ########################################################################################################
+      # Let's now grow the watch window in the case of a xpub watcher...
+      watching_by_pub32_id=$(echo "${row}" | cut -d '|' -f3)
+      if [ -n "${watching_by_pub32_id}" ]; then
+        trace "[confirmation] Let's now grow the watch window in the case of a xpub watcher"
+
+        pub32_index=$(echo "${row}" | cut -d '|' -f4)
+        extend_watchers "${watching_by_pub32_id}" "${pub32_index}"
+      fi
+      ########################################################################################################
+
+      ########################################################################################################
+      # Let's publish the event if needed
+      event_message=$(echo "${row}" | cut -d '|' -f5)
+      if [ -n "${event_message}" ]; then
+        # There's an event message, let's publish it!
+
+        trace "[confirmation] mosquitto_pub -h broker -t tx_confirmation -m \"{\"txid\":\"${txid}\",\"hash\":\"${tx_hash}\",\"address\":\"${address}\",\"vout_n\":${tx_vout_n},\"amount\":${tx_vout_amount},\"confirmations\":${tx_nb_conf},\"eventMessage\":\"${event_message}\"}\""
+        response=$(mosquitto_pub -h broker -t tx_confirmation -m "{\"txid\":\"${txid}\",\"hash\":\"${tx_hash}\",\"address\":\"${address}\",\"vout_n\":${tx_vout_n},\"amount\":${tx_vout_amount},\"confirmations\":${tx_nb_conf},\"eventMessage\":\"${event_message}\"}")
+        returncode=$?
+        trace_rc ${returncode}
+      fi
+      ########################################################################################################
+
+    done
   else
-    # TX found in our DB.
-    # 1-conf or executecallbacks on an unconfirmed tx or spending watched address (in this case, we probably missed conf) or spending to a watched address (in this case, spend inserted the tx in the DB)
-
-    local tx_blockhash=$(echo "${tx_details}" | jq -r '.blockhash')
-    trace "[confirmation] tx_blockhash=${tx_blockhash}"
-    if [ "${tx_blockhash}" = "null" ]; then
-      trace "[confirmation] probably being called by executecallbacks without any confirmations since the last time we checked"
-    else
-      local tx_blockheight=$(echo "${tx_details}" | jq -r '.blockheight')
-      local tx_blocktime=$(echo "${tx_details}" | jq '.blocktime')
-
-      sql "UPDATE tx SET confirmations=${tx_nb_conf}, blockhash='${tx_blockhash}', blockheight=${tx_blockheight}, blocktime=${tx_blocktime} WHERE txid='${txid}'"
-      trace_rc $?
-    fi
-    id_inserted=${tx}
+    trace "[confirmation]  Exiting flock"
   fi
-  # Delete the temp file containing the raw tx (see above)
-  rm rawtx-${txid}-$$.blob
-
-  ########################################################################################################
-
-  local event_message
-  local watching_id
-
-  # Let's see if we need to insert tx in the join table
-  tx=$(sql "SELECT tx_id FROM watching_tx WHERE tx_id=${id_inserted}")
-
-  for row in ${rows}
-  do
-
-    address=$(echo "${row}" | cut -d '|' -f2)
-    tx_vout_amount=$(echo "${tx_details}" | jq ".details | map(select(.address==\"${address}\"))[0] | .amount | fabs" | awk '{ printf "%.8f", $0 }')
-    # In the case of us spending to a watched address, the address appears twice in the details,
-    # once on the spend side (negative amount) and once on the receiving side (positive amount)
-    tx_vout_n=$(echo "${tx_details}" | jq ".details | map(select(.address==\"${address}\"))[0] | .vout")
-
-    ########################################################################################################
-    # Let's now insert in the join table if not already done
-    if [ -z "${tx}" ]; then
-      trace "[confirmation] For this tx, there's no watching_tx row, let's create it"
-
-      # If the tx is batched and pays multiple watched addresses, we have to insert
-      # those additional addresses in watching_tx!
-      watching_id=$(echo "${row}" | cut -d '|' -f1)
-      sql "INSERT INTO watching_tx (watching_id, tx_id, vout, amount) VALUES (${watching_id}, ${id_inserted}, ${tx_vout_n}, ${tx_vout_amount})"\
-" ON CONFLICT DO NOTHING"
-      trace_rc $?
-    else
-      trace "[confirmation] For this tx, there's already watching_tx rows"
-    fi
-    ########################################################################################################
-
-    ########################################################################################################
-    # Let's now grow the watch window in the case of a xpub watcher...
-    watching_by_pub32_id=$(echo "${row}" | cut -d '|' -f3)
-    if [ -n "${watching_by_pub32_id}" ]; then
-      trace "[confirmation] Let's now grow the watch window in the case of a xpub watcher"
-
-      pub32_index=$(echo "${row}" | cut -d '|' -f4)
-      extend_watchers "${watching_by_pub32_id}" "${pub32_index}"
-    fi
-    ########################################################################################################
-
-    ########################################################################################################
-    # Let's publish the event if needed
-    event_message=$(echo "${row}" | cut -d '|' -f5)
-    if [ -n "${event_message}" ]; then
-      # There's an event message, let's publish it!
-
-      trace "[confirmation] mosquitto_pub -h broker -t tx_confirmation -m \"{\"txid\":\"${txid}\",\"hash\":\"${tx_hash}\",\"address\":\"${address}\",\"vout_n\":${tx_vout_n},\"amount\":${tx_vout_amount},\"confirmations\":${tx_nb_conf},\"eventMessage\":\"${event_message}\"}\""
-      response=$(mosquitto_pub -h broker -t tx_confirmation -m "{\"txid\":\"${txid}\",\"hash\":\"${tx_hash}\",\"address\":\"${address}\",\"vout_n\":${tx_vout_n},\"amount\":${tx_vout_amount},\"confirmations\":${tx_nb_conf},\"eventMessage\":\"${event_message}\"}")
-      returncode=$?
-      trace_rc ${returncode}
-    fi
-    ########################################################################################################
-
-  done
-
   ) 9>./.confirmation.lock
 
   # There's a lock in callbacks, let's get out of the confirmation lock before entering another one

--- a/proxy_docker/app/script/confirmation.sh
+++ b/proxy_docker/app/script/confirmation.sh
@@ -86,6 +86,7 @@
 
 # 2: boolean bypass_callbacks (optional)
 #
+
 confirmation() {
   trace "[confirmation] Entering confirmation()..."
 
@@ -98,14 +99,8 @@ confirmation() {
   local txid=$(echo "$tx_details" | jq .txid | tr -d \")
 
   (
-  flock --verbose -x 9 1>&2 
-
-  local returncode
-  local tx_details=$(echo "${1}" | base64 -d)
-  local bypass_callbacks=${2}
-
-  trace "[confirmation] tx_details=${tx_details}"
-  trace "[confirmation] bypass_callbacks=${bypass_callbacks}"
+  local flock_output=$(flock --verbose --timeout 60 9) || (trace "[confirmation]  Exiting - flock_output=${flock_output}" && return 0)
+  trace "[confirmation] flock_output=${flock_output}"
 
   local returncode
 
@@ -277,7 +272,7 @@ confirmation() {
     trace "[confirmation] Skipping callbacks as requested"
   fi
 
-  echo '{"result":"confirmed"}'
+  #echo '{"result":"confirmed"}'
 
   return 0
 }

--- a/proxy_docker/app/script/confirmation.sh
+++ b/proxy_docker/app/script/confirmation.sh
@@ -116,7 +116,7 @@ confirmation() {
 
     local notfirst=false
     local IFS="
-  "
+"
     for address in ${addresses}
     do
       trace "[confirmation] address=${address}"

--- a/proxy_docker/app/script/confirmation.sh
+++ b/proxy_docker/app/script/confirmation.sh
@@ -98,7 +98,7 @@ confirmation() {
   local txid=$(echo "$tx_details" | jq .txid | tr -d \")
 
   (
-  flock --verbose -x 9
+  flock --verbose -x 9 1>&2 
 
   local returncode
   local tx_details=$(echo "${1}" | base64 -d)

--- a/proxy_docker/app/script/confirmation.sh
+++ b/proxy_docker/app/script/confirmation.sh
@@ -108,7 +108,6 @@ confirmation() {
   trace "[confirmation] bypass_callbacks=${bypass_callbacks}"
 
   local returncode
-  local txid=$(echo "$tx_details" | jq .txid | tr -d \")
 
   ########################################################################################################
   # First of all, let's make sure we're working on watched addresses...

--- a/proxy_docker/app/script/confirmation.sh
+++ b/proxy_docker/app/script/confirmation.sh
@@ -87,11 +87,20 @@
 # 2: boolean bypass_callbacks (optional)
 #
 confirmation() {
+  trace "[confirmation] Entering confirmation()..."
+
+  local tx_details=$(echo "${1}" | base64 -d)
+  local bypass_callbacks=${2}
+
+  trace "[confirmation] tx_details=${tx_details}"
+  trace "[confirmation] bypass_callbacks=${bypass_callbacks}"
+
+  local txid=$(echo "$tx_details" | jq .txid | tr -d \")
+
   (
-  flock -x 9
+  flock --verbose -x 9
 
-  trace "Entering confirmation()..."
-
+  local returncode
   local tx_details=$(echo "${1}" | base64 -d)
   local bypass_callbacks=${2}
 
@@ -265,6 +274,8 @@ confirmation() {
   if [ -z "${bypass_callbacks}" ]; then
     trace "[confirmation] Let's do the callbacks!"
     do_callbacks "${txid}"
+  else
+    trace "[confirmation] Skipping callbacks as requested"
   fi
 
   echo '{"result":"confirmed"}'

--- a/proxy_docker/app/script/newblock.sh
+++ b/proxy_docker/app/script/newblock.sh
@@ -7,7 +7,7 @@
 
 newblock() {
   (
-  flock -x 7
+  flock --verbose -x 7
 
   trace "Entering newblock()..."
 

--- a/proxy_docker/app/script/newblock.sh
+++ b/proxy_docker/app/script/newblock.sh
@@ -9,27 +9,30 @@ newblock() {
   trace "Entering newblock()..."
 
   (
-  local flock_output=$(flock --verbose --timeout 60 7) || (trace "[newblock]  Exiting - flock_output=${flock_output}" && return 0)
-  trace "[newblock] flock_output=${flock_output}"
-
-  local request=${1}
-  local blockhash=$(echo "${request}" | cut -d ' ' -f2 | cut -d '/' -f3)
-
-  local blockinfo
-  blockinfo=$(get_block_info "${blockhash}")
-
-  local blockheight
-  blockheight=$(echo "${blockinfo}" | jq -r ".result.height")
-
-  trace "[newblock] mosquitto_pub -h broker -t newblock -m \"{\"blockhash\":\"${blockhash}\",\"blockheight\":${blockheight}}\""
-  response=$(mosquitto_pub -h broker -t newblock -m "{\"blockhash\":\"${blockhash}\",\"blockheight\":${blockheight}}")
+  local flock_output
+  flock_output=$(flock --verbose --timeout 60 7)
   returncode=$?
-  trace_rc ${returncode}
+  trace "[newblock] flock_output=${flock_output}"
+  if [ "$returncode" -eq "0" ]; then
+    local request=${1}
+    local blockhash=$(echo "${request}" | cut -d ' ' -f2 | cut -d '/' -f3)
 
-  # do_callbacks_txid "$(echo "${blockinfo}" | jq ".result.tx[]")"
-  do_callbacks_txid
-  batch_check_webhooks
+    local blockinfo
+    blockinfo=$(get_block_info "${blockhash}")
 
+    local blockheight
+    blockheight=$(echo "${blockinfo}" | jq -r ".result.height")
+
+    trace "[newblock] mosquitto_pub -h broker -t newblock -m \"{\"blockhash\":\"${blockhash}\",\"blockheight\":${blockheight}}\""
+    response=$(mosquitto_pub -h broker -t newblock -m "{\"blockhash\":\"${blockhash}\",\"blockheight\":${blockheight}}")
+    returncode=$?
+    trace_rc ${returncode}
+
+    # do_callbacks_txid "$(echo "${blockinfo}" | jq ".result.tx[]")"
+    do_callbacks_txid
+    batch_check_webhooks
+  else
+    trace "[newblock]  Exiting flock"
+  fi
   ) 7>./.newblock.lock
 }
-

--- a/proxy_docker/app/script/newblock.sh
+++ b/proxy_docker/app/script/newblock.sh
@@ -7,7 +7,7 @@
 
 newblock() {
   (
-  flock --verbose -x 7
+  flock --verbose -x 7 1>&2 
 
   trace "Entering newblock()..."
 

--- a/proxy_docker/app/script/newblock.sh
+++ b/proxy_docker/app/script/newblock.sh
@@ -6,10 +6,11 @@
 . ./batching.sh
 
 newblock() {
-  (
-  flock --verbose -x 7 1>&2 
-
   trace "Entering newblock()..."
+
+  (
+  local flock_output=$(flock --verbose --timeout 60 7) || (trace "[newblock]  Exiting - flock_output=${flock_output}" && return 0)
+  trace "[newblock] flock_output=${flock_output}"
 
   local request=${1}
   local blockhash=$(echo "${request}" | cut -d ' ' -f2 | cut -d '/' -f3)
@@ -31,3 +32,4 @@ newblock() {
 
   ) 7>./.newblock.lock
 }
+

--- a/proxy_docker/app/script/requesthandler.sh
+++ b/proxy_docker/app/script/requesthandler.sh
@@ -260,8 +260,8 @@ main() {
         executecallbacks)
           # curl (GET) http://192.168.111.152:8080/executecallbacks
 
-          manage_not_imported
-          manage_missed_conf
+          response=$(manage_not_imported)
+          response=$(manage_missed_conf)
           response=$(do_callbacks)
           returncode=$?
           ;;

--- a/proxy_docker/app/tests/test-make-watch-noise.sh
+++ b/proxy_docker/app/tests/test-make-watch-noise.sh
@@ -58,7 +58,7 @@ make_watch_noise(){
     trace 3 "[${me}] address=${address}"
 
     trace 2 "[${me}] watch it..."
-    local data='{"address":"'${address}'","unconfirmedCallbackURL":"'${url0}'","confirmedCallbackURL":"'${url1}'","label":"label-no-space_${port}"}'
+    local data='{"address":"'${address}'","unconfirmedCallbackURL":"'${url0}'","confirmedCallbackURL":"'${url1}'","label":"label space '${port}'"}'
     trace 3 "[${me}] data=${data}"
     response=$(exec_in_test_container curl -d "${data}" proxy:8888/watch)
     trace 3 "[${me}] response=${response}"

--- a/proxy_docker/app/tests/test-make-watch-noise.sh
+++ b/proxy_docker/app/tests/test-make-watch-noise.sh
@@ -58,7 +58,7 @@ make_watch_noise(){
     trace 3 "[${me}] address=${address}"
 
     trace 2 "[${me}] watch it..."
-    local data='{"address":"'${address}'","unconfirmedCallbackURL":"'${url0}'","confirmedCallbackURL":"'${url1}'","label":"label make some noise '${port}'"}'
+    local data='{"address":"'${address}'","unconfirmedCallbackURL":"'${url0}'","confirmedCallbackURL":"'${url1}'","label":"label-no-space_${port}"}'
     trace 3 "[${me}] data=${data}"
     response=$(exec_in_test_container curl -d "${data}" proxy:8888/watch)
     trace 3 "[${me}] response=${response}"

--- a/proxy_docker/app/tests/test-make-watch-noise.sh
+++ b/proxy_docker/app/tests/test-make-watch-noise.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+DIR="$( dirname -- "${BASH_SOURCE[0]}"; )"; 
+. $DIR/colors.sh
+. $DIR/mine.sh
+
+
+# This needs to be run in regtest
+# You need jq installed for these tests to run correctly
+#
+# It will add watch addresses with no callback listening 
+# We had to create this to inject 10 wrong callbacks and run test-manage-missed.sh
+# When we switched to Debian, the request thread was getting killed when a subprocess was writing to stdout.  Turns out we made a
+# fix in the request handler to redirects stdout into a variable instead of the actual output stream.  Debian netcat was killing the thread
+# when the caller (curl) was closing the connection after receiving a non HTTP 1.1 response
+
+
+trace() {
+  if [ "${1}" -le "${TRACING}" ]; then
+    echo -e "$(date -u +%FT%TZ) ${2}" 1>&2
+  fi
+}
+
+start_test_container() {
+  docker run -d --rm -t --name tests-make-watch-noise --network=cyphernodenet alpine
+}
+
+stop_test_container() {
+  trace 1 "\n\n[stop_test_container] ${BCyan}Stopping existing containers if they are running...${Color_Off}\n"
+
+  # docker stop tests-make-watch-noise
+  local containers=$(docker ps -q -f "name=tests-make-watch-noise")
+  if [ -n "${containers}" ]; then
+    docker stop ${containers}
+  fi
+}
+
+exec_in_test_container() {
+  docker exec -it tests-make-watch-noise "$@"
+}
+
+make_watch_noise(){
+  local me="${BCyan}make_watch_noise${Color_Off}"
+  local noise_level=${1:-1}
+
+  trace 1 "[${me}] ${BCyan}Let's ${me} - ${noise_level}...${Color_Off}"
+
+  for ((loop=0; loop<${noise_level}; loop++));
+  do
+    local port=$RANDOM
+    local url0="tests-make-watch-noise:${port}/NEVERcallback0conf${port}"
+    local url1="tests-make-watch-noise:${port}/NEVERcallback1conf${port}"
+
+    trace 2 "[${me}] getnewaddress..."
+    local response=$(exec_in_test_container curl -d '{"label":"make some noise '${loop}'"}' proxy:8888/getnewaddress)
+    trace 3 "[${me}] response=${response}"
+    local address=$(echo "${response}" | jq -r ".address")
+    trace 3 "[${me}] address=${address}"
+
+    trace 2 "[${me}] watch it..."
+    local data='{"address":"'${address}'","unconfirmedCallbackURL":"'${url0}'","confirmedCallbackURL":"'${url1}'","label":"label make some noise '${port}'"}'
+    trace 3 "[${me}] data=${data}"
+    response=$(exec_in_test_container curl -d "${data}" proxy:8888/watch)
+    trace 3 "[${me}] response=${response}"
+
+    trace 3 "[${me}] Sending coins to watched address..."
+    docker exec -it $(docker ps -q -f "name=cyphernode.bitcoin") bitcoin-cli -rpcwallet=spending01.dat sendtoaddress ${address} 0.00001234
+  done
+
+  mine
+
+  trace 1 "[${me}] ${BCyan}Done${Color_Off}"
+}
+
+TRACING=3
+
+stop_test_container
+start_test_container
+
+exec_in_test_container apk add --update curl
+
+make_watch_noise "$@"
+
+stop_test_container


### PR DESCRIPTION
Fix for flock (use -n instead of -x)

Requesthandler - executecallbacks was letting echos to stdout stream instead of a variable

New test script to inject watches with no available callbacks - for minor load testing

confirmations.sh : fix to enable the 2nd parameter bypass_callback to be used.  The flock block was shadowing the variable so I took it out