### PR TITLE
Fixed permission issues in a few files ~/cyphernode/dist/*.sh

### DIFF
--- a/dist/setup.sh
+++ b/dist/setup.sh
@@ -682,25 +682,29 @@ install_docker() {
 
   if ${sudo} [ ! -x $current_path/start.sh ]; then
     step "     [32mmake[0m start.sh executable"
-    try chmod +x $current_path/start.sh
+    sudo_if_required chown -R $USER $current_path/start.sh
+    sudo_if_required chmod +x $current_path/start.sh
     next
   fi
 
   if ${sudo} [ ! -x $current_path/stop.sh ]; then
     step "     [32mmake[0m stop.sh executable"
-    try chmod +x $current_path/stop.sh
+    sudo_if_required chown -R $USER $current_path/stop.sh
+    sudo_if_required chmod +x $current_path/stop.sh
     next
   fi
 
   if ${sudo} [ ! -x $current_path/testfeatures.sh ]; then
     step "     [32mmake[0m testfeatures.sh executable"
-    try chmod +x $current_path/testfeatures.sh
+    sudo_if_required chown -R $USER $current_path/testfeatures.sh
+    sudo_if_required chmod +x $current_path/testfeatures.sh
     next
   fi
 
   if ${sudo} [ ! -x $current_path/testdeployment.sh ]; then
     step "     [32mmake[0m testdeployment.sh executable"
-    try chmod +x $current_path/testdeployment.sh
+    sudo_if_required chown -R $USER $current_path/testdeployment.sh
+    sudo_if_required chmod +x $current_path/testdeployment.sh
     next
   fi
 }


### PR DESCRIPTION
added `sudo_if_required` and chown on a few files in dist

Still get these errors. Not able to find them in .cyphernodeconf/bitcoin/{wallet,block}notify.sh

```
     make walletnotify.sh executablechmod: cannot access '/home/ishi/Orgs/i5hi/cyphernode/dist/cyphernode/bitcoin/walletnotify.sh': No such file or directory
                                                                     [ FAILED ]
     make blocknotify.sh executablechmod: cannot access '/home/ishi/Orgs/i5hi/cyphernode/dist/cyphernode/bitcoin/blocknotify.sh': No such file or directory
                                                                     [ FAILED ]
```