### PR TITLE
add missing env var exports to stop.sh

### DIFF
--- a/cyphernodeconf_docker/templates/installer/stop.sh
+++ b/cyphernodeconf_docker/templates/installer/stop.sh
@@ -30,9 +30,11 @@ stop_apps() {
         export TOR_DATAPATH
         export LIGHTNING_DATAPATH
         export BITCOIN_DATAPATH
+        export LOGS_DATAPATH
         export APP_SCRIPT_PATH
         export APP_ID
         export DOCKER_MODE
+        export NETWORK=<%= net %>
 
         if [ "$DOCKER_MODE" = "swarm" ]; then
           docker stack rm $APP_ID


### PR DESCRIPTION
The LOGS_DATAPATH and NETWORK vars are exported again as in the start script, otherwise taking down the containers that use these vars in their docker-compose file gives an error.