### PR TITLE
fix: quote issue in watch when invalid address provided

### DIFF
--- a/proxy_docker/app/script/watchrequest.sh
+++ b/proxy_docker/app/script/watchrequest.sh
@@ -97,7 +97,7 @@ watchrequest() {
 '"message":"Invalid address",'\
 '"data":{'\
 '"event":"watch",'\
-'"address":"'${address}'",'\
+'"address":'"\"${address}\""','\
 '"unconfirmedCallbackURL":'${cb0conf_url_json}','\
 '"confirmedCallbackURL":'${cb1conf_url_json}','\
 '"label":'${label_json}','\


### PR DESCRIPTION
Small fix to correct bad JSON data when an invalid address is passed to watch address