### PR TITLE
Bug fix: bitcoin_getfeerate fallback

### DIFF
--- a/proxy_docker/app/script/bitcoin.sh
+++ b/proxy_docker/app/script/bitcoin.sh
@@ -386,7 +386,7 @@ getfeerate() {
 
   if [ "${returncode}" -eq 0 ]; then
     feerate=$(echo ${response} | jq ".result.feerate")
-    feerate=$(awk "BEGIN { printf \"%d\", $feerate * 100000000 }")
+    feerate=$(awk "BEGIN { printf \"%d\", $feerate * 100000000 / 1024 }")
     trace "[getfeerate] feerate=${feerate}"
 
     data="{\"feerate\":\"${feerate}\"}"


### PR DESCRIPTION
In bitcoin_getfeerate when mempool.space instances aren't available the function will fall back to bitcoin-cli estimatesmartfee.

When that happens the function was returning the feerate as BTC/kvB instead of sats/vB like the mempool.space values.

This change fixes that.