### PR TITLE
elements template: ZMQ raw publishers + discount CT

### DIFF
--- a/cyphernodeconf_docker/templates/elements/elements.conf
+++ b/cyphernodeconf_docker/templates/elements/elements.conf
@@ -3,6 +3,18 @@ txindex=1
 maxmempool=64
 dbcache=64
 
+# Raw ZMQ notifications for cypherapps that watch the chain directly
+# (e.g. the Boltz cypherapp); mirrors bitcoin.conf's publishers on 18501/18502.
+# Container-internal on cyphernodenet — not published on the host.
+zmqpubrawblock=tcp://0.0.0.0:18601
+zmqpubrawtx=tcp://0.0.0.0:18602
+
+# Discounted-fee confidential transactions (ELIP-0200); supported by the
+# pinned elements v23.2.5 and assumed by Liquid fee estimation in modern
+# wallets/services (discounted vsize accounting)
+acceptdiscountct=1
+creatediscountct=1
+
 mainchainrpchost=<%= (bitcoin_mode === 'internal')?'bitcoin':bitcoin_node_ip %>
 mainchainrpcport=<%= (net === 'regtest') ? '18443' : ((net === 'testnet') ? '18332' : '8332') %>
 mainchainrpcuser=<%= bitcoin_rpcuser %>


### PR DESCRIPTION
## What

Four config lines in `cyphernodeconf_docker/templates/elements/elements.conf` (global section):

- `zmqpubrawblock=tcp://0.0.0.0:18601` / `zmqpubrawtx=tcp://0.0.0.0:18602` — raw ZMQ notifications, mirroring the bitcoin template's existing publishers (18501/18502). Container-internal on `cyphernodenet`; nothing is published on the host.
- `acceptdiscountct=1` / `creatediscountct=1` — discounted-fee confidential transactions (ELIP-0200), supported by the pinned `cyphernode/elements:v23.2.5`.

## Why

The bitcoin template already ships raw ZMQ publishers, so a cypherapp that watches the chain directly can subscribe to Bitcoin but not to Liquid. This brings the elements template to parity, so that any cypherapp needing raw block and transaction notifications — a common requirement, usually discovered through `getzmqnotifications` — can get them from elementsd the same way.

Discounted confidential transactions are the current Liquid fee convention: modern wallets and services assume discounted vsize accounting, and a node that neither accepts nor creates such transactions estimates Liquid fees against the wrong basis.

## Notes

- ZMQ publishing has negligible cost when nothing subscribes; existing deployments are unaffected until a subscriber appears.
- Both publishers are needed together — subscribers that use `getzmqnotifications` for discovery generally expect the pair.
- Base: `bullishnode/liquid2-dev-ready` (PR #366), since the elements template lives on the liquid2 lineage.
