### PR TITLE
liquid2: exact-wallet balance queries + gatekeeper hardening

### DIFF
--- a/api_auth_docker/api-sample.properties
+++ b/api_auth_docker/api-sample.properties
@@ -103,6 +103,7 @@ action_elements_deriveindex=spender
 action_elements_derivepubpath=spender
 action_elements_get_txns_spending=spender
 action_elements_getbalance=spender
+action_elements_getbalances=spender
 action_elements_getnewaddress=spender
 action_elements_getwalletinfo=spender
 action_elements_spend=spender

--- a/api_auth_docker/auth.sh
+++ b/api_auth_docker/auth.sh
@@ -181,9 +181,11 @@ verify_group() {
   trace "[verify_group] needed_group=${needed_group}"
 
   # If needed_group is empty, the action was not found in api.propeties.
+  # Comma-anchored match: group names must match as whole tokens so a group
+  # can never be granted because its name is a substring of another group.
   if [ -n "${needed_group}" ]; then
-    case "${ugroups}" in
-      *${needed_group}*) trace "[verify_group] Access granted"; return 0 ;;
+    case ",${ugroups}," in
+      *",${needed_group},"*) trace "[verify_group] Access granted"; return 0 ;;
     esac
   fi
 

--- a/cyphernodeconf_docker/templates/gatekeeper/api.properties
+++ b/cyphernodeconf_docker/templates/gatekeeper/api.properties
@@ -101,6 +101,7 @@ action_elements_deriveindex=spender
 action_elements_derivepubpath=spender
 action_elements_get_txns_spending=spender
 action_elements_getbalance=spender
+action_elements_getbalances=spender
 action_elements_getnewaddress=spender
 action_elements_getwalletinfo=spender
 action_elements_spend=spender

--- a/cyphernodeconf_docker/templates/gatekeeper/default.conf
+++ b/cyphernodeconf_docker/templates/gatekeeper/default.conf
@@ -12,6 +12,9 @@ server {
 
   location /v0/ {
     auth_request /auth;
+    # The caller's bearer token authenticates against the gatekeeper only;
+    # it must never be forwarded to the unauthenticated internal proxy.
+    proxy_set_header Authorization "";
     proxy_pass http://proxy:8888/;
 
     # Up default 60 second timeout for 3 minutes (OTS stamping can take time)

--- a/proxy_docker/app/script/elements_walletoperations.sh
+++ b/proxy_docker/app/script/elements_walletoperations.sh
@@ -247,18 +247,37 @@ elements_getbalance() {
 elements_getbalances() {
   trace "Entering elements_getbalances()..."
 
+  local wallet_selector=${1:-}
+  local wallet_name=${2:-}
   local response
   local data='{"method":"getbalances"}'
-  response=$(send_to_elements_spender_node "${data}")
+  if [ -n "${wallet_name}" ]; then
+    response=$(send_getbalances_to_elements_spender_wallet_name "${wallet_name}")
+  elif [ -n "${wallet_selector}" ]; then
+    response=$(send_to_elements_spender_node "${data}" "${wallet_selector}")
+  else
+    response=$(send_to_elements_spender_node "${data}")
+  fi
   local returncode=$?
   trace_rc ${returncode}
   trace "[elements_getbalances] response=${response}"
 
   if [ "${returncode}" -eq 0 ]; then
-    local balances=$(echo "${response}" | jq ".result")
-    trace "[elements_getbalances] balances=${balances}"
-
-    data="{\"balances\":${balances}}"
+    local balances
+    balances=$(printf '%s' "${response}" | jq -ce '.result | select(type == "object")')
+    if [ "$?" -ne 0 ]; then
+      trace "[elements_getbalances] Node returned invalid balance data"
+      returncode=1
+      data=""
+    else
+      trace "[elements_getbalances] balances=${balances}"
+      data=$(jq -cn --argjson balances "${balances}" '{balances: $balances}')
+      if [ "$?" -ne 0 ]; then
+        trace "[elements_getbalances] Could not encode balance response"
+        returncode=1
+        data=""
+      fi
+    fi
   else
     trace "[elements_getbalances] Couldn't get balances!"
     data=""

--- a/proxy_docker/app/script/requesthandler.sh
+++ b/proxy_docker/app/script/requesthandler.sh
@@ -31,6 +31,19 @@
 . ./elements_pegout.sh
 . ./paymentalist.sh
 
+wallet_name_from_request() {
+  printf '%s' "${1:-}" | jq -er '
+    if type == "object"
+      and (.walletName | type) == "string"
+      and (.walletName | length) > 0
+      and (.walletName | length) <= 255
+      and ((.walletName | test("[[:cntrl:]]")) | not)
+    then .walletName
+    else error("invalid walletName")
+    end
+  '
+}
+
 main() {
   trace "Entering main()..."
 
@@ -295,14 +308,25 @@ main() {
         getbalances)
           # curl (GET) http://192.168.111.152:8080/getbalances
           # curl (GET) http://192.168.111.152:8080/getbalances/01 (spending wallet number)
+          # curl -H "Content-Type: application/json" -d '{"walletName":"treasury wallet.dat"}' http://192.168.111.152:8080/getbalances
 
-          walletname=$(echo "${line}" | cut -d ' ' -f2 | cut -d '/' -f3)
-          if [ "${walletname}" = "getbalances" ]; then
-            walletname=""
+          if [ "${http_method}" = "POST" ]; then
+            if walletname=$(wallet_name_from_request "${line}"); then
+              response=$(getbalances "" "${walletname}")
+              returncode=$?
+            else
+              response='{"error":{"code":-32602,"message":"walletName must be a non-empty string of at most 255 characters without control characters"},"id":"1"}'
+              returncode=1
+            fi
+          else
+            walletname=$(echo "${line}" | cut -d ' ' -f2 | cut -d '/' -f3)
+            if [ "${walletname}" = "getbalances" ]; then
+              walletname=""
+            fi
+
+            response=$(getbalances "${walletname}")
+            returncode=$?
           fi
-
-          response=$(getbalances "${walletname}")
-          returncode=$?
           ;;
         getbalancebyxpub)
           # curl (GET) http://192.168.111.152:8080/getbalancebyxpub/upub5GtUcgGed1aGH4HKQ3vMYrsmLXwmHhS1AeX33ZvDgZiyvkGhNTvGd2TA5Lr4v239Fzjj4ZY48t6wTtXUy2yRgapf37QHgt6KWEZ6bgsCLpb
@@ -1098,6 +1122,29 @@ main() {
 
           response=$(elements_getbalance "${wallet}")
           returncode=$?
+          ;;
+        elements_getbalances)
+          # curl (GET) http://192.168.111.152:8080/elements_getbalances
+          # curl (GET) http://192.168.111.152:8080/elements_getbalances/01 (spending wallet number)
+          # curl -H "Content-Type: application/json" -d '{"walletName":"liquid/reserve.dat"}' http://192.168.111.152:8080/elements_getbalances
+
+          if [ "${http_method}" = "POST" ]; then
+            if walletname=$(wallet_name_from_request "${line}"); then
+              response=$(elements_getbalances "" "${walletname}")
+              returncode=$?
+            else
+              response='{"error":{"code":-32602,"message":"walletName must be a non-empty string of at most 255 characters without control characters"},"id":"1"}'
+              returncode=1
+            fi
+          else
+            wallet=$(echo "${line}" | cut -d ' ' -f2 | cut -d '/' -f3)
+            if [ "${wallet}" = "elements_getbalances" ]; then
+              wallet=""
+            fi
+
+            response=$(elements_getbalances "${wallet}")
+            returncode=$?
+          fi
           ;;
         elements_gettransaction)
           # curl (GET) http://192.168.111.152:8080/elements_gettransaction/7a45ba9de1f6fbd17e123762cd5b27f18a02a72d581d019abf1030e6a5677178

--- a/proxy_docker/app/script/sendtobitcoinnode.sh
+++ b/proxy_docker/app/script/sendtobitcoinnode.sh
@@ -54,6 +54,39 @@ send_to_spender_node() {
   return ${returncode}
 }
 
+# Read balances from one exact, operator-configured wallet name. This is kept
+# separate from send_to_spender_node(), whose optional argument is a legacy
+# numeric selector used by all spender operations.
+send_getbalances_to_spender_wallet_name() {
+  trace "Entering send_getbalances_to_spender_wallet_name()..."
+
+  local walletname=${1:-}
+  local encoded_walletname
+  local returncode
+
+  if [ -z "${walletname}" ]; then
+    trace "[send_getbalances_to_spender_wallet_name] Missing wallet name"
+    return 1
+  fi
+
+  encoded_walletname=$(printf '%s' "${walletname}" | jq -sRr '@uri')
+  returncode=$?
+  trace_rc ${returncode}
+  if [ "${returncode}" -ne 0 ] || [ -z "${encoded_walletname}" ]; then
+    trace "[send_getbalances_to_spender_wallet_name] Could not encode wallet name"
+    return 1
+  fi
+
+  trace "[send_getbalances_to_spender_wallet_name] wallet: ${walletname}"
+  send_to_bitcoin_node \
+    "${SPENDER_BTC_NODE_RPC_URL}/${encoded_walletname}" \
+    "${SPENDER_BTC_NODE_RPC_CFG}" \
+    '{"method":"getbalances"}'
+  returncode=$?
+  trace_rc ${returncode}
+  return ${returncode}
+}
+
 send_to_bitcoin_node() {
   trace "Entering send_to_bitcoin_node()..."
   local returncode

--- a/proxy_docker/app/script/sendtobitcoinnode.sh
+++ b/proxy_docker/app/script/sendtobitcoinnode.sh
@@ -72,6 +72,12 @@ send_getbalances_to_spender_wallet_name() {
   encoded_walletname=$(printf '%s' "${walletname}" | jq -sRr '@uri')
   returncode=$?
   trace_rc ${returncode}
+  # curl normalizes literal dot path segments, which would rewrite the
+  # /wallet/<name> RPC target; encode dot-only names so they survive.
+  case "${walletname}" in
+    .) encoded_walletname='%2E' ;;
+    ..) encoded_walletname='%2E%2E' ;;
+  esac
   if [ "${returncode}" -ne 0 ] || [ -z "${encoded_walletname}" ]; then
     trace "[send_getbalances_to_spender_wallet_name] Could not encode wallet name"
     return 1

--- a/proxy_docker/app/script/sendtoelementsnode.sh
+++ b/proxy_docker/app/script/sendtoelementsnode.sh
@@ -78,6 +78,12 @@ send_getbalances_to_elements_spender_wallet_name()
   encoded_walletname=$(printf '%s' "${walletname}" | jq -sRr '@uri')
   returncode=$?
   trace_rc ${returncode}
+  # curl normalizes literal dot path segments, which would rewrite the
+  # /wallet/<name> RPC target; encode dot-only names so they survive.
+  case "${walletname}" in
+    .) encoded_walletname='%2E' ;;
+    ..) encoded_walletname='%2E%2E' ;;
+  esac
   if [ "${returncode}" -ne 0 ] || [ -z "${encoded_walletname}" ]; then
     trace "[send_getbalances_to_elements_spender_wallet_name] Could not encode wallet name"
     return 1

--- a/proxy_docker/app/script/sendtoelementsnode.sh
+++ b/proxy_docker/app/script/sendtoelementsnode.sh
@@ -59,6 +59,40 @@ send_to_elements_spender_node()
   return ${returncode}
 }
 
+# Read balances from one exact, operator-configured wallet name. This is kept
+# separate from send_to_elements_spender_node(), whose optional argument is a
+# legacy numeric selector used by all spender operations.
+send_getbalances_to_elements_spender_wallet_name()
+{
+  trace "Entering send_getbalances_to_elements_spender_wallet_name()..."
+
+  local walletname=${1:-}
+  local encoded_walletname
+  local returncode
+
+  if [ -z "${walletname}" ]; then
+    trace "[send_getbalances_to_elements_spender_wallet_name] Missing wallet name"
+    return 1
+  fi
+
+  encoded_walletname=$(printf '%s' "${walletname}" | jq -sRr '@uri')
+  returncode=$?
+  trace_rc ${returncode}
+  if [ "${returncode}" -ne 0 ] || [ -z "${encoded_walletname}" ]; then
+    trace "[send_getbalances_to_elements_spender_wallet_name] Could not encode wallet name"
+    return 1
+  fi
+
+  trace "[send_getbalances_to_elements_spender_wallet_name] wallet: ${walletname}"
+  send_to_elements_node \
+    "${SPENDER_ELEMENTS_NODE_RPC_URL}/${encoded_walletname}" \
+    "${SPENDER_ELEMENTS_NODE_RPC_CFG}" \
+    '{"method":"getbalances"}'
+  returncode=$?
+  trace_rc ${returncode}
+  return ${returncode}
+}
+
 send_to_elements_node()
 {
   trace "Entering send_to_elements_node()..."

--- a/proxy_docker/app/script/walletoperations.sh
+++ b/proxy_docker/app/script/walletoperations.sh
@@ -718,11 +718,14 @@ getbalance() {
 getbalances() {
   trace "Entering getbalances()..."
 
-  local wallet=${1:-}
+  local wallet_selector=${1:-}
+  local wallet_name=${2:-}
   local response
   local data='{"method":"getbalances"}'
-  if [ -n "${wallet}" ]; then
-    response=$(send_to_spender_node "${data}" "${wallet}")
+  if [ -n "${wallet_name}" ]; then
+    response=$(send_getbalances_to_spender_wallet_name "${wallet_name}")
+  elif [ -n "${wallet_selector}" ]; then
+    response=$(send_to_spender_node "${data}" "${wallet_selector}")
   else
     response=$(send_to_spender_node "${data}")
   fi
@@ -731,10 +734,21 @@ getbalances() {
   trace "[getbalances] response=${response}"
 
   if [ "${returncode}" -eq 0 ]; then
-    local balances=$(echo "${response}" | jq ".result")
-    trace "[getbalances] balances=${balances}"
-
-    data="{\"balances\":${balances}}"
+    local balances
+    balances=$(printf '%s' "${response}" | jq -ce '.result | select(type == "object")')
+    if [ "$?" -ne 0 ]; then
+      trace "[getbalances] Node returned invalid balance data"
+      returncode=1
+      data=""
+    else
+      trace "[getbalances] balances=${balances}"
+      data=$(jq -cn --argjson balances "${balances}" '{balances: $balances}')
+      if [ "$?" -ne 0 ]; then
+        trace "[getbalances] Could not encode balance response"
+        returncode=1
+        data=""
+      fi
+    fi
   else
     trace "[getbalances] Couldn't get balances!"
     data=""

--- a/proxy_docker/app/tests/test-elements-getbalances.sh
+++ b/proxy_docker/app/tests/test-elements-getbalances.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+DIR="$( dirname -- "${BASH_SOURCE[0]}"; )"
+. "$DIR/colors.sh"
+
+# This should be run against a regtest deployment with the Elements feature enabled.
+
+trace() {
+  if [ "${1}" -le "${TRACING}" ]; then
+    echo -e "$(date -u +%FT%TZ) ${2}" 1>&2
+  fi
+}
+
+start_test_container() {
+  docker run -d --rm -t --name tests-elements-getbalances --network=cyphernodenet alpine:3.15.4
+}
+
+stop_test_container() {
+  local containers
+  containers=$(docker ps -q -f "name=tests-elements-getbalances")
+  if [ -n "${containers}" ]; then
+    docker stop ${containers} >/dev/null
+  fi
+}
+
+exec_in_test_container() {
+  docker exec tests-elements-getbalances "$@"
+}
+
+balances_match() {
+  local response="$1"
+  local direct="$2"
+
+  echo "${response}" | jq -e --argjson expected "${direct}" \
+    '.balances == $expected' >/dev/null
+}
+
+test_elements_getbalances() {
+  local bitcoin_container
+  local elements_container
+  local response
+  local direct
+  local http_code
+
+  bitcoin_container=$(docker ps -q -f "network=cyphernodenet" \
+    -f "label=com.docker.compose.service=bitcoin")
+  elements_container=$(docker ps -q -f "network=cyphernodenet" \
+    -f "label=com.docker.compose.service=elements")
+  [ -n "${bitcoin_container}" ] || return 4
+  [ -n "${elements_container}" ] || return 5
+
+  trace 1 "[test_elements_getbalances] Verifying the legacy Bitcoin selector..."
+  response=$(exec_in_test_container curl -s proxy:8888/getbalances/01)
+  direct=$(docker exec -t "${bitcoin_container}" \
+    bitcoin-cli -rpcwallet=spending01.dat getbalances | tr -d '\r')
+  balances_match "${response}" "${direct}" || return 8
+
+  trace 1 "[test_elements_getbalances] Verifying the default Bitcoin wallet remains available..."
+  response=$(exec_in_test_container curl -s proxy:8888/getbalances)
+  balances_match "${response}" "${direct}" || return 9
+
+  trace 1 "[test_elements_getbalances] Querying an exact, non-spender Bitcoin wallet name..."
+  response=$(exec_in_test_container curl -s \
+    -H "Content-Type: application/json" \
+    --data '{"walletName":"watching01.dat"}' \
+    proxy:8888/getbalances)
+  direct=$(docker exec -t "${bitcoin_container}" \
+    bitcoin-cli -rpcwallet=watching01.dat getbalances | tr -d '\r')
+  balances_match "${response}" "${direct}" || return 10
+
+  trace 1 "[test_elements_getbalances] Querying spending01.dat through the wallet-scoped endpoint..."
+  response=$(exec_in_test_container curl -s proxy:8888/elements_getbalances/01)
+  echo "${response}" | jq -e '
+    .balances.mine.trusted
+    and .balances.mine.untrusted_pending
+    and .balances.mine.immature
+  ' >/dev/null || return 10
+
+  direct=$(docker exec -t "${elements_container}" \
+    elements-cli -rpcwallet=spending01.dat getbalances | tr -d '\r')
+  balances_match "${response}" "${direct}" || return 20
+
+  trace 1 "[test_elements_getbalances] Verifying the default Elements wallet remains available..."
+  response=$(exec_in_test_container curl -s proxy:8888/elements_getbalances)
+  balances_match "${response}" "${direct}" || return 30
+
+  trace 1 "[test_elements_getbalances] Querying an exact, non-spender Elements wallet name..."
+  response=$(exec_in_test_container curl -s \
+    -H "Content-Type: application/json" \
+    --data '{"walletName":"watching01.dat"}' \
+    proxy:8888/elements_getbalances)
+  direct=$(docker exec -t "${elements_container}" \
+    elements-cli -rpcwallet=watching01.dat getbalances | tr -d '\r')
+  balances_match "${response}" "${direct}" || return 35
+
+  trace 1 "[test_elements_getbalances] Verifying an unknown selector does not fall back..."
+  http_code=$(exec_in_test_container curl -s -o /dev/null -w "%{http_code}" \
+    proxy:8888/elements_getbalances/999999)
+  [ "${http_code}" = "400" ] || return 40
+
+  trace 1 "[test_elements_getbalances] Verifying an unknown exact name does not fall back..."
+  http_code=$(exec_in_test_container curl -s -o /dev/null -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    --data '{"walletName":"definitely-not-a-wallet.dat"}' \
+    proxy:8888/elements_getbalances)
+  [ "${http_code}" = "400" ] || return 45
+
+  trace 1 "[test_elements_getbalances] Rejecting an empty exact name before wallet lookup..."
+  http_code=$(exec_in_test_container curl -s -o /dev/null -w "%{http_code}" \
+    -H "Content-Type: application/json" \
+    --data '{"walletName":""}' \
+    proxy:8888/elements_getbalances)
+  [ "${http_code}" = "400" ] || return 50
+
+  trace 1 "[test_elements_getbalances] ${On_IGreen}${BBlack}SUCCESS${Color_Off}"
+}
+
+TRACING=3
+
+stop_test_container
+trap stop_test_container EXIT
+start_test_container >/dev/null
+exec_in_test_container apk add --no-cache curl >/dev/null
+
+test_elements_getbalances


### PR DESCRIPTION
Two additions for the Liquid2 release branch, both required by downstream consumers that address operator-named wallets:

**Exact-wallet balance queries over POST.** `getbalances` and `elements_getbalances` accept `POST {"walletName": ...}` carrying the wallet name byte-for-byte (validated: non-empty, <=255 chars, no control characters; percent-encoded into the `/wallet/<name>` RPC path, including dot-only names which curl path normalization would otherwise rewrite). `elements_getbalances` previously existed as a function but had no request case and no gatekeeper registration — it is now reachable and registered. Balance responses fail closed on malformed node RPC results. Legacy GET selector routes unchanged.

**Gatekeeper hardening.** Group names now match as whole comma-separated tokens (a group can never be authorized because its name is a substring of another group's list), and the caller's Authorization header is stripped before proxying so gatekeeper bearer tokens are never forwarded to the unauthenticated internal proxy.