### PR TITLE
Liquid Release: review fixes (unwatch asset scope, gatekeeper auth strip, migration test)

### DIFF
--- a/api_auth_docker/default.conf
+++ b/api_auth_docker/default.conf
@@ -12,6 +12,9 @@ server {
 
   location /v0/ {
     auth_request /auth;
+    # The caller's bearer token authenticates against the gatekeeper only;
+    # it must never be forwarded to the unauthenticated internal proxy.
+    proxy_set_header Authorization "";
     proxy_pass http://proxy:8888/;
 
     # Up default 60 second timeout for 3 minutes (OTS stamping can take time)

--- a/contrib/liquid2-merge-readiness/migration-dev-to-liquid2.sh
+++ b/contrib/liquid2-merge-readiness/migration-dev-to-liquid2.sh
@@ -107,6 +107,35 @@ pass "candidate migrations completed from origin/dev schema"
 run_migrations
 pass "candidate migrations are idempotent on second run"
 
+# The origin/dev seed has no Elements tables, so the first run creates them
+# fresh with the final 4-column index and the asset-index migration takes its
+# skip branch — its DROP/CREATE is never exercised. Simulate a real
+# pre-liquid2 install by downgrading the index to the old 3-column form (with
+# a live watch row present), then re-run: this forces the migration's
+# transactional DROP/CREATE to execute against existing data.
+docker run --rm --network "$network_name" "$PROXY_IMAGE" sh -c '
+  set -e
+  psql -v ON_ERROR_STOP=1 -h postgres -U cyphernode -c "
+    DROP INDEX IF EXISTS idx_elements_watching_01;
+    CREATE UNIQUE INDEX idx_elements_watching_01 ON elements_watching (address, COALESCE(callback0conf, '\'''\''), COALESCE(callback1conf, '\'''\''));
+    INSERT INTO elements_watching (address, unblinded_address, watching, callback0conf, callback1conf, watching_assetid, imported)
+    VALUES ('\''ert1qliquid2migrationelementswatch00000000000000'\'', '\''ert1qliquid2migrationelementswatch00000000000000'\'', true, '\''http://127.0.0.1:1/0conf'\'', '\''http://127.0.0.1:1/1conf'\'', '\''6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d'\'', true);
+  " >/dev/null
+'
+pass "downgraded Elements watch index to the pre-liquid2 3-column form with a live watch row"
+
+run_migrations
+pass "candidate migrations upgraded the pre-liquid2 3-column index"
+
+docker run --rm --network "$network_name" "$PROXY_IMAGE" sh -c '
+  set -e
+  psql -qAtX -v ON_ERROR_STOP=1 -h postgres -U cyphernode -c "
+    SELECT COALESCE((SELECT indexdef LIKE '\''%COALESCE(watching_assetid%'\'' FROM pg_indexes WHERE indexname = '\''idx_elements_watching_01'\''), false);
+    SELECT COUNT(*) = 1 FROM elements_watching WHERE watching_assetid = '\''6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d'\'';
+  " | grep -qxF f && exit 1 || exit 0
+'
+pass "asset-index migration executed its DROP/CREATE and preserved the pre-existing watch row"
+
 docker run --rm --network "$network_name" "$PROXY_IMAGE" sh -c '
   set -e
   psql -qAtX -v ON_ERROR_STOP=1 -h postgres -U cyphernode -c "
@@ -115,7 +144,7 @@ docker run --rm --network "$network_name" "$PROXY_IMAGE" sh -c '
     SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '\''elements_watching'\'');
     SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '\''elements_watching_by_txid'\'');
     SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = '\''elements_watching'\'' AND column_name = '\''watching_assetid'\'');
-    SELECT indexdef LIKE '\''%COALESCE(watching_assetid%'\'' FROM pg_indexes WHERE indexname = '\''idx_elements_watching_01'\'';
+    SELECT COALESCE((SELECT indexdef LIKE '\''%COALESCE(watching_assetid%'\'' FROM pg_indexes WHERE indexname = '\''idx_elements_watching_01'\''), false);
   " | grep -qxF f && exit 1 || exit 0
 '
 pass "Bitcoin data survived and Liquid tables/indexes exist after migration"

--- a/proxy_docker/app/script/elements_unwatchrequest.sh
+++ b/proxy_docker/app/script/elements_unwatchrequest.sh
@@ -10,9 +10,10 @@ elements_unwatchrequest() {
   local address=${2}
   local unconfirmedCallbackURL=${3}
   local confirmedCallbackURL=${4}
+  local assetId=${5}
   local returncode
 
-  trace "[elements_unwatchrequest] Unwatch request id ${watchid} on address \"${address}\" with url0conf \"${unconfirmedCallbackURL}\" and url1conf \"${confirmedCallbackURL}\""
+  trace "[elements_unwatchrequest] Unwatch request id ${watchid} on address \"${address}\" with url0conf \"${unconfirmedCallbackURL}\" and url1conf \"${confirmedCallbackURL}\" asset \"${assetId}\""
 
   if [ "${watchid}" != "null" ]; then
     case "${watchid}" in
@@ -29,7 +30,8 @@ elements_unwatchrequest() {
   else
     local cb0_where=
     local cb1_where=
-    local address_pg address_json cb0_json cb1_json
+    local asset_where=
+    local address_pg address_json cb0_json cb1_json asset_json
 
     if [ "${address}" = "null" ] || [ -z "${address}" ]; then
       echo '{"result":null,"error":{"code":-5,"message":"address or id required"}}'
@@ -37,6 +39,16 @@ elements_unwatchrequest() {
     fi
     address_pg=$(sql_string_literal "${address}")
     address_json=$(json_string_literal "${address}")
+
+    # An asset-scoped watch identity means one address can carry several
+    # watches. When the caller names an asset, target only that one; otherwise
+    # preserve the historical behavior of clearing every asset on the address.
+    if [ "${assetId}" != "null" ] && [ -n "${assetId}" ]; then
+      asset_where=" AND watching_assetid=$(sql_string_literal "${assetId}")"
+      asset_json=$(json_string_literal "${assetId}")
+    else
+      asset_json="null"
+    fi
 
     if [ "${unconfirmedCallbackURL}" != "null" ]; then
       cb0_where=" AND callback0conf=$(sql_string_literal "${unconfirmedCallbackURL}")"
@@ -51,11 +63,14 @@ elements_unwatchrequest() {
       cb1_json="null"
     fi
 
-    sql "UPDATE elements_watching SET watching=false WHERE address=${address_pg}${cb0_where}${cb1_where}"
+    # Match either the confidential or the unconfidential form: watches are
+    # found by (address OR unblinded_address) elsewhere, and the watch response
+    # returns both, so a caller may hold either one.
+    sql "UPDATE elements_watching SET watching=false WHERE (address=${address_pg} OR unblinded_address=${address_pg})${cb0_where}${cb1_where}${asset_where}"
     returncode=$?
     trace_rc ${returncode}
 
-    data="{\"event\":\"elements_unwatch\",\"address\":${address_json},\"unconfirmedCallbackURL\":${cb0_json},\"confirmedCallbackURL\":${cb1_json}}"
+    data="{\"event\":\"elements_unwatch\",\"address\":${address_json},\"unconfirmedCallbackURL\":${cb0_json},\"confirmedCallbackURL\":${cb1_json},\"assetId\":${asset_json}}"
   fi
 
   trace "[elements_unwatchrequest] responding=${data}"

--- a/proxy_docker/app/script/requesthandler.sh
+++ b/proxy_docker/app/script/requesthandler.sh
@@ -1091,6 +1091,7 @@ main() {
           local unconfirmedCallbackURL="null"
           local confirmedCallbackURL="null"
           local watchid="null"
+          local assetId="null"
 
           # Let's make it work even for a GET request (equivalent to a POST with empty json object body)
           if [ "$http_method" = "POST" ]; then
@@ -1098,11 +1099,12 @@ main() {
             unconfirmedCallbackURL=$(echo "${line}" | jq -r ".unconfirmedCallbackURL")
             confirmedCallbackURL=$(echo "${line}" | jq -r ".confirmedCallbackURL")
             watchid=$(echo "${line}" | jq ".id")
+            assetId=$(echo "${line}" | jq -r ".assetId")
           else
             address=$(echo "${line}" | cut -d ' ' -f2 | cut -d '/' -f3)
           fi
 
-          response=$(elements_unwatchrequest "${watchid}" "${address}" "${unconfirmedCallbackURL}" "${confirmedCallbackURL}")
+          response=$(elements_unwatchrequest "${watchid}" "${address}" "${unconfirmedCallbackURL}" "${confirmedCallbackURL}" "${assetId}")
           returncode=$?
           ;;
         elements_conf)


### PR DESCRIPTION
Fixes from the deep review of the Liquid Release, scoped to BullishNode/Francis-authored findings that are not mitigated at the deployment/network layer.

**fix(elements): scope unwatch by asset + match unconfidential address.** The asset dimension was added to the watch identity but not to unwatch, so an address carrying per-asset watches couldn't be unwatched individually (clearing one cleared all). Unwatch now takes an optional `assetId` (clear-all preserved when omitted) and matches the unconfidential address form too — unwatching by the unblinded address was previously a silent no-op.

**fix(gatekeeper): strip client Authorization in the image-baked nginx conf.** The Authorization-strip hardening was in the generated config but not `api_auth_docker/default.conf` — the copy baked into the image and exercised by the gatekeeper test suite. Synced for coverage and defense in depth.

**test(liquid2): actually exercise the asset-index migration.** The harness seeded a schema with no Elements tables, so the asset-index migration always took its skip branch and its DROP/CREATE was never tested. Added a downgrade-then-re-migrate step with a live watch row, and fixed the final index assertion, which passed vacuously when the index was absent.

Deferred by decision: multi-output payment crediting (needs a deliberate design fix to the ±detail normalization + unique index, not a drive-by patch). Out of authorship scope (reported separately to authors): walletnotify watch-only lookup, P2P port default, setup.sh chmod path, mainnet peer whitelist. Considered and dropped as deployment/network-mitigated: exact-wallet spender read scope, docker-network-only SQL interpolation.